### PR TITLE
Chore/ga4gh production config

### DIFF
--- a/deployments/ga4gh/prod/config-local.json
+++ b/deployments/ga4gh/prod/config-local.json
@@ -2,7 +2,7 @@
   "htsgetConfig": {
     "props": {
       "port": "3000",
-      "host": "https://htsget.ga4gh.org/",
+      "host": "http://localhost:3000/",
       "docsDir": "./deployments/ga4gh/prod/docs/",
       "tempDir": "/tmp/",
       "logFile": "/usr/src/app/htsget-refserver.log"
@@ -18,6 +18,18 @@
           {
             "pattern": "^tabulamuris\\.(?P<accession>.*)$",
             "path": "https://s3.amazonaws.com/czbiohub-tabula-muris/facs_bam_files/{accession}.mus.Aligned.out.sorted.bam"
+          },
+          {
+            "pattern": "^giab\\.NA12878\\.NIST7035\\.(?P<lane>.*)$",
+            "path": "https://giab.s3.amazonaws.com/data/NA12878/Garvan_NA12878_HG001_HiSeq_Exome/project.NIST_NIST7035_H7AP8ADXX_TAAGGCGA_{lane}_NA12878.bwa.markDuplicates.bam"
+          },
+          {
+            "pattern": "^giab\\.NA12878\\.NIST7086\\.(?P<lane>.*)$",
+            "path": "https://giab.s3.amazonaws.com/data/NA12878/Garvan_NA12878_HG001_HiSeq_Exome/project.NIST_NIST7086_H7AP8ADXX_CGTACTAG_{lane}_NA12878.bwa.markDuplicates.bam"
+          },
+          {
+            "pattern": "^gatk\\.(?P<accession>.*)$",
+            "path": "./data/gcp/gatk-test-data/wgs_bam/{accession}.bam"
           }
         ]
       },
@@ -42,8 +54,20 @@
       "dataSourceRegistry": {
         "sources": [
           {
-            "pattern": "^1000genomes\\.(?P<accession>.*)$",
-            "path": "https://ftp-trace.ncbi.nih.gov/1000genomes/ftp/phase1/analysis_results/integrated_call_sets/{accession}.vcf.gz"
+            "pattern": "^1000genomes\\.phase1\\.(?P<accession>chrY)$",
+            "path": "https://ftp-trace.ncbi.nih.gov/1000genomes/ftp/phase1/analysis_results/integrated_call_sets/ALL.{accession}.phase1_samtools_si.20101123.snps.low_coverage.genotypes.vcf.gz"
+          },
+          {
+            "pattern": "^1000genomes\\.phase1\\.(?P<accession>chrMT)$",
+            "path": "https://ftp-trace.ncbi.nih.gov/1000genomes/ftp/phase1/analysis_results/integrated_call_sets/ALL.{accession}.phase1_samtools_si.20101123.snps.low_coverage.genotypes.vcf.gz"
+          },
+          {
+            "pattern": "^1000genomes\\.phase1\\.(?P<accession>.*)$",
+            "path": "https://ftp-trace.ncbi.nih.gov/1000genomes/ftp/phase1/analysis_results/integrated_call_sets/ALL.{accession}.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.vcf.gz"
+          },
+          {
+            "pattern": "^giab\\.(?P<accession>NA12878)$",
+            "path": "https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/{accession}_HG001/NISTv3.3/NA12878_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-Solid-10X_CHROM1-X_v3.3_highconf.vcf.gz"
           }
         ]
       },

--- a/deployments/ga4gh/prod/config-server.json
+++ b/deployments/ga4gh/prod/config-server.json
@@ -1,0 +1,91 @@
+{
+  "htsgetConfig": {
+    "props": {
+      "port": "3000",
+      "host": "https://htsget.ga4gh.org/",
+      "docsDir": "./deployments/ga4gh/prod/docs/",
+      "tempDir": "/tmp/",
+      "logFile": "/usr/src/app/htsget-refserver.log"
+    },
+    "reads": {
+      "enabled": true,
+      "dataSourceRegistry": {
+        "sources": [
+          {
+            "pattern": "^tabulamuris\\.(?P<accession>10X.*)$",
+            "path": "https://s3.amazonaws.com/czbiohub-tabula-muris/10x_bam_files/{accession}_possorted_genome.bam"
+          },
+          {
+            "pattern": "^tabulamuris\\.(?P<accession>.*)$",
+            "path": "https://s3.amazonaws.com/czbiohub-tabula-muris/facs_bam_files/{accession}.mus.Aligned.out.sorted.bam"
+          },
+          {
+            "pattern": "^giab\\.NA12878\\.NIST7035\\.(?P<lane>.*)$",
+            "path": "https://giab.s3.amazonaws.com/data/NA12878/Garvan_NA12878_HG001_HiSeq_Exome/project.NIST_NIST7035_H7AP8ADXX_TAAGGCGA_{lane}_NA12878.bwa.markDuplicates.bam"
+          },
+          {
+            "pattern": "^giab\\.NA12878\\.NIST7086\\.(?P<lane>.*)$",
+            "path": "https://giab.s3.amazonaws.com/data/NA12878/Garvan_NA12878_HG001_HiSeq_Exome/project.NIST_NIST7086_H7AP8ADXX_CGTACTAG_{lane}_NA12878.bwa.markDuplicates.bam"
+          },
+          {
+            "pattern": "^gatk\\.(?P<accession>.*)$",
+            "path": "./data/gcp/gatk-test-data/wgs_bam/{accession}.bam"
+          }
+        ]
+      },
+      "serviceInfo": {
+        "id": "org.ga4gh.htsgetreference.reads",
+        "name": "GA4GH htsget reference server reads API",
+        "description": "Reference web service of the GA4GH htsget protocol. Streams alignment data from public datasets, such as Tabula Muris and 1000 Genomes.",
+        "organization": {
+          "name": "Global Alliance for Genomics and Health",
+          "url": "https://ga4gh.org"
+        },
+        "contactUrl": "mailto:jeremy.adams@ga4gh.org",
+        "documentationUrl": "https://ga4gh.github.io/htsget-refserver/docs/index.html",
+        "createdAt": "2019-09-15T12:00:00Z",
+        "updatedAt": "2020-09-04T14:40:00Z",
+        "environment": "production",
+        "version": "1.3.0"
+      }
+    },
+    "variants": {
+      "enabled": true,
+      "dataSourceRegistry": {
+        "sources": [
+          {
+            "pattern": "^1000genomes\\.phase1\\.(?P<accession>chrY)$",
+            "path": "https://ftp-trace.ncbi.nih.gov/1000genomes/ftp/phase1/analysis_results/integrated_call_sets/ALL.{accession}.phase1_samtools_si.20101123.snps.low_coverage.genotypes.vcf.gz"
+          },
+          {
+            "pattern": "^1000genomes\\.phase1\\.(?P<accession>chrMT)$",
+            "path": "https://ftp-trace.ncbi.nih.gov/1000genomes/ftp/phase1/analysis_results/integrated_call_sets/ALL.{accession}.phase1_samtools_si.20101123.snps.low_coverage.genotypes.vcf.gz"
+          },
+          {
+            "pattern": "^1000genomes\\.phase1\\.(?P<accession>.*)$",
+            "path": "https://ftp-trace.ncbi.nih.gov/1000genomes/ftp/phase1/analysis_results/integrated_call_sets/ALL.{accession}.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.vcf.gz"
+          },
+          {
+            "pattern": "^giab\\.(?P<accession>NA12878)$",
+            "path": "https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/{accession}_HG001/NISTv3.3/NA12878_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-Solid-10X_CHROM1-X_v3.3_highconf.vcf.gz"
+          }
+        ]
+      },
+      "serviceInfo": {
+        "id": "org.ga4gh.htsgetreference.variants",
+        "name": "GA4GH htsget reference server variants API",
+        "description": "Reference web service of the GA4GH htsget protocol. Streams variant data from public datasets, such as Tabula Muris and 1000 Genomes.",
+        "organization": {
+          "name": "Global Alliance for Genomics and Health",
+          "url": "https://ga4gh.org"
+        },
+        "contactUrl": "mailto:jeremy.adams@ga4gh.org",
+        "documentationUrl": "https://ga4gh.github.io/htsget-refserver/docs/index.html",
+        "createdAt": "2020-08-31T08:00:00Z",
+        "updatedAt": "2020-09-04T14:40:00Z",
+        "environment": "production",
+        "version": "1.3.0"
+      }
+    }
+  }
+}

--- a/deployments/ga4gh/prod/docs/index.html
+++ b/deployments/ga4gh/prod/docs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>ReDoc</title>
+    <title>GA4GH htsget reference server</title>
     <!-- needed for adaptive design -->
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/deployments/ga4gh/prod/docs/index.html
+++ b/deployments/ga4gh/prod/docs/index.html
@@ -1,14 +1,24 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <title>ReDoc</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
 
-<head>
-  <meta charset="UTF-8">
-  <title>HTSget reference server</title>
-</head>
-
-<body>
-  <p>Welcome to the HTSget reference server.</p>
-  <p>This server serves the publicly available Tabula-Muris dataset on AWS according to the HTSget protocol.</p>
-</body>
-
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <redoc spec-url='/docs/openapi.yaml'></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+  </body>
 </html>

--- a/deployments/ga4gh/prod/docs/openapi.yaml
+++ b/deployments/ga4gh/prod/docs/openapi.yaml
@@ -3,22 +3,140 @@ info:
     title: GA4GH htsget reference server (prod)
     description: |
         Welcome to the GA4GH-hosted, production deployment of the htsget
-        reference server 
+        reference server.
+
+        This is a running deployment of the
+        [htsget reference server codebase](https://github.com/ga4gh/htsget-refserver),
+        which streams open alignment and variant datasets according to the
+        [GA4GH htsget protocol](http://samtools.github.io/hts-specs/htsget.html).
 
         The API's base url is: https://htsget.ga4gh.org/
         * ex: https://htsget.ga4gh.org/reads/service-info
         * ex: https://htsget.ga4gh.org/variants/service-info
 
-
-        # Introduction
-
-        Introduction
-
         # Datasets
+        This section lists the various open datasets that are available via the
+        htsget reference server, and how to go about requesting sample files.
 
         ## Reads Datasets
 
+        `IDs` described here can be provided to the `/reads/{id}` endpoint to
+        stream alignment data according to the htsget protocol.
+
+        #### Tabula Muris SmartSeq2 FACS BAM files
+
+        FACS-based full length transcripts from the
+        [Tabula Muris](https://tabula-muris.ds.czbiohub.org/) dataset can be
+        streamed via the API.
+        
+        [This resource](https://github.com/czbiohub/tabula-muris/blob/master/tabula-muris-on-aws.md)
+        outlines where these BAM files are located on AWS S3. Using the AWS
+        Command Line Interface, the bucket files can be listed with the following
+        command:
+        `aws s3 ls s3://czbiohub-tabula-muris/facs_bam_files/`
+
+        To convert a desired file into an `ID` for the htsget API, `tabulamuris.`
+        must be prepended to the filename, and `.mus.Aligned.out.sorted.bam`
+        must be removed. For example, for the filename 
+        `A1-B000126-3_39_F-1-1_R1.mus.Aligned.out.sorted.bam`, the `ID` provided to
+        the API would be `tabulamuris.A1-B000126-3_39_F-1-1_R1`
+
+        There are 99,840 Tabula Muris FACS BAMs available for streaming, some IDs include:
+        `tabulamuris.A1-B000126-3_39_F-1-1_R1`,
+        `tabulamuris.A1-B000126-3_39_F-1-1_R2`,
+        `tabulamuris.A1-B000127-3_38_F-1-1_R1`,
+        `tabulamuris.A1-B000127-3_38_F-1-1_R2`
+
+        #### Tabula Muris 10x BAM files
+
+        10x single-cell transcripts from the
+        [Tabula Muris](https://tabula-muris.ds.czbiohub.org/) dataset can be
+        streamed via the API.
+        
+        [This resource](https://github.com/czbiohub/tabula-muris/blob/master/tabula-muris-on-aws.md)
+        outlines where these BAM files are located on AWS S3. Using the AWS
+        Command Line Interface, the bucket files can be listed with the following
+        command:
+        `aws s3 ls s3://czbiohub-tabula-muris/10x_bam_files/`
+
+        To convert a desired file into an `ID` for the htsget API, `tabulamuris.`
+        must be prepended to the filename, and `_possorted_genome.bam`
+        must be removed. For example, for the filename 
+        `A1-B000126-3_39_F-1-1_R1.mus.Aligned.out.sorted.bam`, the `ID` provided to
+        the API would be `tabulamuris.A1-B000126-3_39_F-1-1_R1`
+
+        There are 28 Tabula Muris 10x BAMs available for streaming, some IDs include:
+        `tabulamuris.10X_P4_0`,
+        `tabulamuris.10X_P4_1`,
+        `tabulamuris.10X_P4_2`,
+        `tabulamuris.10X_P4_3`
+
+        #### Genome in a Bottle NA12878/HG001 BAMs
+
+        Lane-level BAMs from one individual (NA12878/HG001) from the
+        [Genome in a Bottle Consortium](https://www.nist.gov/programs-projects/genome-bottle)
+        project can be streamed via the API. The BAMs within
+        [this FTP directory](https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/data/NA12878/Garvan_NA12878_HG001_HiSeq_Exome/)
+        are available.
+
+        According to the [README](https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/data/NA12878/Garvan_NA12878_HG001_HiSeq_Exome/Garvan_NA12878_HG001_HiSeq_Exome.README),
+        2 DNA libraries (NIST7035 and NIST7086) were prepared from the individual,
+        and each library was sequenced on 2 lanes, for a total of 4 lane level BAMs.
+
+        Any of the following IDs may be provided to the `/reads/{id}` endpoint
+        to stream the different lane-level BAMs:
+        `giab.NA12878.NIST7035.1`, `giab.NA12878.NIST7035.2`,
+        `giab.NA12878.NIST7086.1`, `giab.NA12878.NIST7086.2`,
+
+        #### GATK Test Data
+
+        Small test BAMs used for building and testing of the 
+        [Genome Analysis Toolkit](https://gatk.broadinstitute.org/)
+        can be streamed via the API.
+
+        The following IDs may be provided to the `/reads/{id}` endpoint to
+        stream the GATK test BAMs:
+        `gatk.NA12878`, `gatk.NA12878_20k_b37`
+
         ## Variants Datasets
+
+        `IDs` described here can be provided to the `/variants/{id}` endpoint to
+        stream variant data according to the htsget protocol.
+
+        #### 1000 Genomes Phase 1 Integrated Call Sets
+
+        Integrated variant data from phase 1 of the
+        [1000 Genomes Project](https://www.internationalgenome.org/)
+        can be streamed when using the `1000genomes.phase1` identifier prefix.
+        Essentially, the chromosome-specific VCFs within
+        [this FTP directory](https://ftp-trace.ncbi.nih.gov/1000genomes/ftp/phase1/analysis_results/integrated_call_sets/)
+        are available.
+
+        Any of the following IDs may be provided to the `/variants/{id}` endpoint
+        to stream chromosome-specific VCF data:
+        `1000genomes.phase1.chr1`, `1000genomes.phase1.chr2`, `1000genomes.phase1.chr3`,
+        `1000genomes.phase1.chr4`, `1000genomes.phase1.chr5`, `1000genomes.phase1.chr6`,
+        `1000genomes.phase1.chr7`, `1000genomes.phase1.chr8`, `1000genomes.phase1.chr9`, 
+        `1000genomes.phase1.chr10`, `1000genomes.phase1.chr11`, `1000genomes.phase1.chr12`,
+        `1000genomes.phase1.chr13`, `1000genomes.phase1.chr14`, `1000genomes.phase1.chr15`,
+        `1000genomes.phase1.chr16`, `1000genomes.phase1.chr17`, `1000genomes.phase1.chr18`,
+        `1000genomes.phase1.chr19`, `1000genomes.phase1.chr20`, `1000genomes.phase1.chr21`,
+        `1000genomes.phase1.chr22`, `1000genomes.phase1.chrX`, `1000genomes.phase1.chrY`,
+        `1000genomes.phase1.chrMT`
+
+        #### Genome in a Bottle NA12878/HG001 High Confidence calls
+
+        Variants from one individual (NA12878/HG001) from the
+        [Genome in a Bottle Consortium](https://www.nist.gov/programs-projects/genome-bottle)
+        project can be streamed via the API. Essentially, the VCF within
+        [this FTP directory](https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/NA12878_HG001/NISTv3.3/)
+        is available.
+
+        To stream NA12878/HG001 variant data, provide the ID `giab.NA12878` 
+        to the `/variants/{id}` endpoint
+
+
+
     version: 1.3.0
     contact:
         name: GA4GH Tech Team
@@ -119,8 +237,41 @@ paths:
             tags:
                 - Reads
                 - Streaming
-            summary: Get Reads data
-            
+            summary: Stream alignment file part
+            description: |
+                Stream a single file part of a requested alignment file. Streams
+                requested region(s), fields, and tags.
+
+                NOTE: This endpoint, while public, should not be requested as an
+                initial request. Rather, the ticket endpoint `/reads/{id}` will
+                yield `URLs` to the `/reads/data/{id}` endpoint.
+            parameters:
+                - $ref: '#/components/parameters/idPathParam'
+                - $ref: '#/components/parameters/readsFormatParam'
+                - $ref: '#/components/parameters/referenceNameParam'
+                - $ref: '#/components/parameters/startParam'
+                - $ref: '#/components/parameters/endParam'
+                - $ref: '#/components/parameters/readsFieldsParam'
+                - $ref: '#/components/parameters/readsTagsParam'
+                - $ref: '#/components/parameters/readsNoTagsParam'
+                - $ref: '#/components/parameters/htsgetBlockClassHeaderParam'
+                - $ref: '#/components/parameters/htsgetCurrentBlockHeaderParam'
+                - $ref: '#/components/parameters/htsgetTotalBlocksHeaderParam'
+            responses:
+                200:
+                    description: Successfully streamed file part of large genomic alignment file
+                    content:
+                        application/octet-stream:
+                            schema:
+                                type: string
+                                format: binary
+                400:
+                    $ref: '#/components/responses/400BadRequestError'
+                404:
+                    $ref: '#/components/responses/404NotFoundError'
+                5xx:
+                    $ref: '#/components/responses/5xxServerError'
+
     /variants/service-info:
         get:
             tags:
@@ -175,13 +326,68 @@ paths:
             tags:
                 - Variants
                 - Streaming
-            summary: Get Variants Data
+            summary: Stream variant file part
+            description: |
+                Stream a single file part of a requested variant file. Streams
+                requested region(s).
+                
+                NOTE: This endpoint, while public, should not be requested as an
+                initial request. Rather, the ticket endpoint `/variants/{id}` 
+                will yields `URLs` to the `/variants/data/{id}` endpoint.
+            parameters:
+                - $ref: '#/components/parameters/idPathParam'
+                - $ref: '#/components/parameters/variantsFormatParam'
+                - $ref: '#/components/parameters/referenceNameParam'
+                - $ref: '#/components/parameters/startParam'
+                - $ref: '#/components/parameters/endParam'
+                - $ref: '#/components/parameters/variantsFieldsParam'
+                - $ref: '#/components/parameters/variantsTagsParam'
+                - $ref: '#/components/parameters/variantsNoTagsParam'
+                - $ref: '#/components/parameters/htsgetBlockClassHeaderParam'
+                - $ref: '#/components/parameters/htsgetCurrentBlockHeaderParam'
+                - $ref: '#/components/parameters/htsgetTotalBlocksHeaderParam'
+            responses:
+                200:
+                    description: Successfully streamed file part of large genomic variant file
+                    content:
+                        application/octet-stream:
+                            schema:
+                                type: string
+                                format: binary
+                400:
+                    $ref: '#/components/responses/400BadRequestError'
+                404:
+                    $ref: '#/components/responses/404NotFoundError'
+                5xx:
+                    $ref: '#/components/responses/5xxServerError'
     
     /file-bytes:
         get:
             tags:
                 - Streaming
             summary: Stream bytes of a local file
+            description: |
+                Streams a single file part of a requested genomic file (reads or variants).
+                This endpoint performs no region filtering or field/tag modification,
+                rather it streams a file part by simple byte positions.
+            parameters:
+                - $ref: '#/components/parameters/htsgetFilePathHeaderParam'
+                - $ref: '#/components/parameters/rangeHeaderParam'
+            responses:
+                200:
+                    description:
+                        Successfully stream file part of large genomic file
+                    content:
+                        application/octet-stream:
+                            schema:
+                                type: string
+                                format: binary
+                400:
+                    $ref: '#/components/responses/400BadRequestError'
+                404:
+                    $ref: '#/components/responses/404NotFoundError'
+                5xx:
+                    $ref: '#/components/responses/5xxServerError'
 
 tags:
     - name: Reads
@@ -216,18 +422,54 @@ components:
                 type: string
                 enum: [QNAME, FLAG, RNAME, POS, MAPQ, CIGAR, RNEXT, PNEXT, TLEN, SEQ, QUAL]
             example: [QNAME, RNAME]
-        # ReadsTags:
-        #     type: array
-        #     description: Description
-        # ReadsNoTags:
-        #     type: array
-        #     description: Description
+        ReadsTags:
+            type: array
+            description: Tags to include in returned alignment file
+            items:
+                type: string
+            example: [MD, NM]
+        ReadsNoTags:
+            type: array
+            description: Tags to exclude from returned alignment file
+            items:
+                type: string
+            example: [OQ, HI]
         
-        
-
+        # GENOMIC INTERVAL, REUSABLE SCHEMAS
+        ReferenceName:
+            type: string
+            description: Reference sequence name
+            example: chr1
+        Start:
+            type: integer
+            description: The start position of the range on the reference, 0-based, inclusive
+            format: int64
+            minimum: 0
+            example: 12312
+        End:
+            type: integer
+            description: The end position of the range on the reference, 0-based, exclusive
+            format: int64
+            example: 99999
+        Region:
+            type: object
+            description: Represents a genomic interval
+            properties:
+                referenceName:
+                    $ref: '#/components/schemas/ReferenceName'
+                start:
+                    $ref: '#/components/schemas/Start'
+                end:
+                    $ref: '#/components/schemas/End'
+            required:
+                - referenceName
+        Regions:
+            type: array
+            description: A listing of genomic intervals
+            items:
+                $ref: '#/components/schemas/Region'
 
         # SERVICE-INFO SCHEMAS
-
         ServiceInfo:
             '$ref': https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-info/v1.0.0/service-info.yaml#/components/schemas/Service
         HtsgetServiceInfoExtension:
@@ -298,40 +540,49 @@ components:
                     $ref: '#/components/schemas/ReadsFormats'
                 fields:
                     $ref: '#/components/schemas/ReadsFields'
-                # tags:
-                #     $ref: '#/components/schemas/ReadsTags'
-                # notags:
-                #     $ref: '#/components/schemas/ReadsNoTags'
-                # regions:
-                #     $ref: '#/components/schemas/Regions'
+                tags:
+                    $ref: '#/components/schemas/ReadsTags'
+                notags:
+                    $ref: '#/components/schemas/ReadsNoTags'
+                regions:
+                    $ref: '#/components/schemas/Regions'
         
         # HTSGET TICKET SCHEMAS
-
+        HtsgetBlockClass:
+            type: string
+            description: When supplied to the data transfer URL, indicates whether a header or body file part is to be returned
+            enum: [header, body]
+            example: header
+        HtsgetCurrentBlock:
+            type: string
+            description: "Indicates the file part's position within the overall downloaded file"
+            example: "0"
+        HtsgetTotalBlocks:
+            type: string
+            description: Indicates how many file parts the overall genomic file transfer has been broken into
+            example: "100"
+        HtsgetFilePath:
+            type: string
+            description: Path to a local file that is to be streamed on simple byte indices
+            example: /data/reads/object00001.bam
+        Range:
+            type: string
+            description: The start/end byte positions of the file to be streamed
+            example: bytes=0-500000
         HtsgetHeaders:
             type: object
             description: Headers that must be supplied in the request to a data transfer URL
             properties:
                 HtsgetBlockClass:
-                    type: string
-                    description: When supplied to the data transfer URL, indicates whether a header or body file part is to be returned
-                    enum: [header, body]
-                    example: header
+                    $ref: '#/components/schemas/HtsgetBlockClass'
                 HtsgetCurrentBlock:
-                    type: string
-                    description: "Indicates the file part's position within the overall downloaded file"
-                    example: "0"
+                    $ref: '#/components/schemas/HtsgetCurrentBlock'
                 HtsgetTotalBlocks:
-                    type: string
-                    description: Indicates how many file parts the overall genomic file transfer has been broken into
-                    example: "100"
-                FilePath:
-                    type: string
-                    description: Path to a local file that is to be streamed on simple byte indices
-                    example: /data/reads/object00001.bam
+                    $ref: '#/components/schemas/HtsgetTotalBlocks'
+                HtsgetFilePath:
+                    $ref: '#/components/schemas/HtsgetFilePath'
                 Range:
-                    type: string
-                    description: The start/end byte positions of the file to be streamed
-                    example: bytes=0-500000
+                    $ref: '#/components/schemas/Range'
         HtsgetUrl:
             type: object
             description: a URL and associated headers that, when requested, perform transfer of a requested file
@@ -396,7 +647,6 @@ components:
                                                             example: "/data/variants/object00001.vcf"
         
         # ERROR SCHEMAS
-
         Error:
             type: object
             properties:
@@ -476,30 +726,21 @@ components:
         referenceNameParam:
             in: query
             name: referenceName
-            description: Reference sequence name
-            example: chr1
             required: false
             schema:
-                type: string
+                $ref: '#/components/schemas/ReferenceName'
         startParam:
             in: query
             name: start
-            description: The start position of the range on the reference, 0-based, inclusive
-            example: 12312
             required: false
             schema:
-                type: integer
-                format: int64
-                minimum: 0
+                $ref: '#/components/schemas/Start'
         endParam:
             in: query
             name: end
-            description: The end position of the range on the reference, 0-based, exclusive
-            example: 99999
             required: false
             schema:
-                type: integer
-                format: int64
+                $ref: '#/components/schemas/End'
         readsFieldsParam:
             in: query
             name: fields
@@ -519,7 +760,7 @@ components:
             example: MD,NM
             required: false
             schema:
-                type: string
+                $ref: '#/components/schemas/ReadsTags'
         variantsTagsParam:
             in: query
             name: tags
@@ -528,14 +769,39 @@ components:
             in: query
             name: notags
             description: A comma-separated list of tags to exclude. By default, i.e., when notags is not specified, no tags will be excluded
-            example: OQ
+            example: OQ,HI
             required: false
             schema:
-                type: string
+                $ref: '#/components/schemas/ReadsNoTags'
         variantsNoTagsParam:
             in: query
             name: notags
             description: Placeholder, currently does not do anything
+        htsgetBlockClassHeaderParam:
+            in: header
+            name: HtsgetBlockClass
+            schema:
+                $ref: '#/components/schemas/HtsgetBlockClass'
+        htsgetCurrentBlockHeaderParam:
+            in: header
+            name: HtsgetCurrentBlock
+            schema:
+                $ref: '#/components/schemas/HtsgetCurrentBlock'
+        htsgetTotalBlocksHeaderParam:
+            in: header
+            name: HtsgetTotalBlocks
+            schema:
+                $ref: '#/components/schemas/HtsgetTotalBlocks'
+        htsgetFilePathHeaderParam:
+            in: header
+            name: HtsgetFilePath
+            schema:
+                $ref: '#/components/schemas/HtsgetFilePath'
+        rangeHeaderParam:
+            in: header
+            name: Range
+            schema:
+                $ref: '#/components/schemas/Range'
     requestBodies:
         ReadsRequestBody:
             description: Specify desired file format, fields, tags, and regions from an alignment file

--- a/deployments/ga4gh/prod/docs/openapi.yaml
+++ b/deployments/ga4gh/prod/docs/openapi.yaml
@@ -1,0 +1,565 @@
+openapi: 3.0.3
+info:
+    title: GA4GH htsget reference server (prod)
+    description: |
+        Welcome to the GA4GH-hosted, production deployment of the htsget
+        reference server 
+
+        The API's base url is: https://htsget.ga4gh.org/
+        * ex: https://htsget.ga4gh.org/reads/service-info
+        * ex: https://htsget.ga4gh.org/variants/service-info
+
+
+        # Introduction
+
+        Introduction
+
+        # Datasets
+
+        ## Reads Datasets
+
+        ## Variants Datasets
+    version: 1.3.0
+    contact:
+        name: GA4GH Tech Team
+        url: https://ga4gh.org
+        email: jeremy.adams@ga4gh.org
+    license:
+        name: Apache 2.0
+        url: https://www.apache.org/licenses/LICENSE-2.0.html
+    x-logo:
+        url: https://www.ga4gh.org/wp-content/themes/ga4gh-theme/gfx/GA-logo-horizontal-tag-RGB.svg
+        backgroundColor: '#00000000'
+        altText: Global Alliance for Genomics and Health
+        href: https://ga4gh.org
+
+servers:
+    - url: https://htsget.ga4gh.org
+      description: Production htsget reference server API
+
+paths:
+    /reads/service-info:
+        get:
+            tags:
+                - Reads
+                - Service Info
+            summary: Get reads service info
+            description: Get metadata about this service's Reads API
+            responses:
+                200:
+                    description: successfully retrieved reads service info
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/HtsgetReadsServiceInfo'
+                5xx:
+                    '$ref': '#/components/responses/5xxServerError'
+    
+    /reads/{id}:
+        get:
+            tags:
+                - Reads
+            summary: Get alignment (reads) file download ticket
+            description: |
+                Gets an htsget ticket containing URLs that will enable the
+                transfer of a requested alignment file
+            parameters:
+                - $ref: '#/components/parameters/idPathParam'
+                - $ref: '#/components/parameters/readsFormatParam'
+                - $ref: '#/components/parameters/classParam'
+                - $ref: '#/components/parameters/referenceNameParam'
+                - $ref: '#/components/parameters/startParam'
+                - $ref: '#/components/parameters/endParam'
+                - $ref: '#/components/parameters/readsFieldsParam'
+                - $ref: '#/components/parameters/readsTagsParam'
+                - $ref: '#/components/parameters/readsNoTagsParam'
+            responses:
+                200:
+                    description: Successfully retrieved htsget ticket
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/HtsgetReadsTicket'
+                400:
+                    $ref: '#/components/responses/400BadRequestError'
+                404:
+                    $ref: '#/components/responses/404NotFoundError'
+                5xx:
+                    $ref: '#/components/responses/5xxServerError'
+
+        post:
+            tags:
+                - Reads
+            summary: Get alignment (reads) file download ticket
+            description: |
+                Gets an htsget ticket containing URLs that will enable the 
+                transfer of a requested alignment file. Compared to the
+                equivalent `GET` endpoint, this `POST` endpoint allows more 
+                complex genomic region requests via the `regions` parameter
+            parameters:
+                - $ref: '#/components/parameters/idPathParam'
+            requestBody:
+                $ref: '#/components/requestBodies/ReadsRequestBody'
+            responses:
+                200:
+                    description: Successfully retrieved htsget ticket
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/HtsgetReadsTicket'
+                400:
+                    $ref: '#/components/responses/400BadRequestError'
+                404:
+                    $ref: '#/components/responses/404NotFoundError'
+                5xx:
+                    $ref: '#/components/responses/5xxServerError'
+    
+    /reads/data/{id}:
+        get:
+            tags:
+                - Reads
+                - Streaming
+            summary: Get Reads data
+            
+    /variants/service-info:
+        get:
+            tags:
+                - Variants
+                - Service Info
+            summary: Get variants service info
+            description: Get metadata about this service's Variants API
+            responses:
+                200:
+                    description: successfully retrieved variants service info
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/HtsgetVariantsServiceInfo'
+                5xx:
+                    $ref: '#/components/responses/5xxServerError'
+    
+    /variants/{id}:
+        get:
+            tags:
+                - Variants
+            summary: Get variant file download ticket
+            description: |
+                Gets an htsget ticket containing URLs that will enable the 
+                transfer of a requested variant file
+            parameters:
+                - $ref: '#/components/parameters/idPathParam'
+                - $ref: '#/components/parameters/variantsFormatParam'
+                - $ref: '#/components/parameters/classParam'
+                - $ref: '#/components/parameters/referenceNameParam'
+                - $ref: '#/components/parameters/startParam'
+                - $ref: '#/components/parameters/endParam'
+                - $ref: '#/components/parameters/variantsFieldsParam'
+                - $ref: '#/components/parameters/variantsTagsParam'
+                - $ref: '#/components/parameters/variantsNoTagsParam'
+            responses:
+                200:
+                    description: Successfully retrieved htsget ticket
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/HtsgetVariantsTicket'
+                400:
+                    $ref: '#/components/responses/400BadRequestError'
+                404:
+                    $ref: '#/components/responses/404NotFoundError'
+                5xx:
+                    $ref: '#/components/responses/5xxServerError'
+    
+    /variants/data/{id}:
+        get:
+            tags:
+                - Variants
+                - Streaming
+            summary: Get Variants Data
+    
+    /file-bytes:
+        get:
+            tags:
+                - Streaming
+            summary: Stream bytes of a local file
+
+tags:
+    - name: Reads
+      description: |
+        Enables the retrieval of genomic alignment files (BAM, CRAM) via the
+        htsget protocol
+    - name: Variants
+      description: |
+        Enables the retrieval of genomic variant files (VCF, BCF) via the
+        htsget protocol
+    - name: Service Info
+      description: |
+        Describes htsget-related API endpoints according to the GA4GH Service Info specification
+      externalDocs:
+        url: https://github.com/ga4gh-discovery/ga4gh-service-info
+    - name: Streaming
+      description: |
+        Large byte transfers of genomic files
+components:
+    schemas:
+
+        # LOW-LEVEL, REUSABLE SCHEMAS
+        ReadsFormats:
+            type: string
+            description: Acceptable file formats for genomic alignment files
+            enum: [BAM, CRAM]
+            example: BAM
+        ReadsFields:
+            type: array
+            description: Acceptable requested fields for genomic alignment files
+            items:
+                type: string
+                enum: [QNAME, FLAG, RNAME, POS, MAPQ, CIGAR, RNEXT, PNEXT, TLEN, SEQ, QUAL]
+            example: [QNAME, RNAME]
+        # ReadsTags:
+        #     type: array
+        #     description: Description
+        # ReadsNoTags:
+        #     type: array
+        #     description: Description
+        
+        
+
+
+        # SERVICE-INFO SCHEMAS
+
+        ServiceInfo:
+            '$ref': https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-info/v1.0.0/service-info.yaml#/components/schemas/Service
+        HtsgetServiceInfoExtension:
+            type: object
+            description: Htsget-specific properties integrated into base service info data model 
+            properties:
+                datatype:
+                    type: string
+                    description: Indicates the htsget API (reads or variants) that this service info endpoint refers to
+                    enum: [reads, variants]
+                formats:
+                    type: array
+                    description: |
+                        The file format(s) that the endpoint supports. Indicates
+                        what values can be submitted via the `?format=` query
+                        parameter
+                    items:
+                        type: string
+                        enum: [BAM, CRAM, VCF, BCF]
+                fieldsParameterEffective:
+                    type: bool
+                    description: |
+                        If true, submitting the `fields` query parameter will
+                        yield custom field inclusion/exclusion according to htsget
+                        protocol
+                    example: true
+                tagsParametersEffective:
+                    type: bool
+                    description: |
+                        If true, submitting the `tags` and/or `notags` query
+                        parameters will yield custom tag inclusion/exclusion
+                        according to htsget protocol
+                    example: true
+        HtsgetServiceInfo:
+            allOf:
+                - '$ref': '#/components/schemas/ServiceInfo'
+                - properties:
+                    type:
+                        properties:
+                            artifact:
+                                example: htsget
+                            version:
+                                example: 1.2.0
+                    htsget:
+                        '$ref': '#/components/schemas/HtsgetServiceInfoExtension'
+                  required:
+                    - htsget
+        HtsgetReadsServiceInfo:
+            allOf:
+                - '$ref': '#/components/schemas/HtsgetServiceInfo'
+        HtsgetVariantsServiceInfo:
+            allOf:
+                - '$ref': '#/components/schemas/HtsgetServiceInfo'
+                - properties:
+                    htsget:
+                        properties:
+                            datatype:
+                                example: variants
+                            formats:
+                                example: VCF
+        
+        # REQUEST BODY SCHEMAS
+        ReadsRequestBody:
+            type: object
+            description: Specify desired file format, fields, tags, and regions from an alignment file
+            properties:
+                format:
+                    $ref: '#/components/schemas/ReadsFormats'
+                fields:
+                    $ref: '#/components/schemas/ReadsFields'
+                # tags:
+                #     $ref: '#/components/schemas/ReadsTags'
+                # notags:
+                #     $ref: '#/components/schemas/ReadsNoTags'
+                # regions:
+                #     $ref: '#/components/schemas/Regions'
+        
+        # HTSGET TICKET SCHEMAS
+
+        HtsgetHeaders:
+            type: object
+            description: Headers that must be supplied in the request to a data transfer URL
+            properties:
+                HtsgetBlockClass:
+                    type: string
+                    description: When supplied to the data transfer URL, indicates whether a header or body file part is to be returned
+                    enum: [header, body]
+                    example: header
+                HtsgetCurrentBlock:
+                    type: string
+                    description: "Indicates the file part's position within the overall downloaded file"
+                    example: "0"
+                HtsgetTotalBlocks:
+                    type: string
+                    description: Indicates how many file parts the overall genomic file transfer has been broken into
+                    example: "100"
+                FilePath:
+                    type: string
+                    description: Path to a local file that is to be streamed on simple byte indices
+                    example: /data/reads/object00001.bam
+                Range:
+                    type: string
+                    description: The start/end byte positions of the file to be streamed
+                    example: bytes=0-500000
+        HtsgetUrl:
+            type: object
+            description: a URL and associated headers that, when requested, perform transfer of a requested file
+            properties:
+                url:
+                    type: string
+                    description: Data transfer URL
+                    example: https://htsget.ga4gh.org/reads/data/object00001?referenceName=chr1
+                headers:
+                    $ref: '#/components/schemas/HtsgetHeaders'
+                class:
+                    type: string
+                    description: Indicates whether the url is responsible for downloading the requested file header or body
+                    enum: [header, body]
+            required:
+                - url
+                - headers
+        HtsgetTicket:
+            type: object
+            description: Container for the htsget ticket
+            properties:
+                htsget:
+                    type: object
+                    description: Contains htsget ticket attributes that will enable genomic file transfer
+                    properties:
+                        format:
+                            type: string
+                            description: The format of the returned file
+                            enum: [BAM, CRAM, VCF, BCF]
+                        urls:
+                            type: array
+                            description: An array of URLs and headers that, when requested, will transfer individual file parts of a requested genomic file
+                            items:
+                                $ref: '#/components/schemas/HtsgetUrl'
+                    required:
+                        - format
+                        - urls
+            required:
+                - htsget
+        HtsgetReadsTicket:
+            $ref: '#/components/schemas/HtsgetTicket'
+        HtsgetVariantsTicket:
+            allOf:
+                - $ref: '#/components/schemas/HtsgetTicket'
+                - properties:
+                    htsget:
+                        properties:
+                            format:
+                                example: VCF
+                            urls:
+                                items:
+                                    allOf:
+                                        - $ref: '#/components/schemas/HtsgetUrl'
+                                        - properties:
+                                            url:
+                                                example: https://htsget.ga4gh.org/variants/data/00001
+                                            headers:
+                                                allOf:
+                                                    - $ref: '#/components/schemas/HtsgetHeaders'
+                                                    - properties:
+                                                        FilePath:
+                                                            example: "/data/variants/object00001.vcf"
+        
+        # ERROR SCHEMAS
+
+        Error:
+            type: object
+            properties:
+                htsget:
+                    type: object
+                    description: Error object container
+                    properties:
+                        error:
+                            type: string
+                            description: Name/type of the error that occurred
+                            example: ServerError
+                        message:
+                            type: string
+                            description: Message explaining why the error occurred
+                            example: An unspecified server error occurred
+                    required:
+                        - error
+                        - message
+            required:
+                - htsget
+        BadRequestError:
+            allOf:
+                - $ref: '#/components/schemas/Error'
+                - properties:
+                    htsget:
+                        properties:
+                            error:
+                                example: InvalidInput
+                            message:
+                                example: "'FOO' is not an acceptable field"
+        NotFoundError:
+            allOf:
+                - $ref: '#/components/schemas/Error'
+                - properties:
+                    htsget:
+                        properties:
+                            error:
+                                example: NotFound
+                            message:
+                                example: The requested resource could not be located
+
+    parameters:
+        idPathParam:
+            in: path
+            name: id
+            description: read or variant object identifier
+            required: true
+            schema:
+                type: string
+        readsFormatParam:
+            in: query
+            name: format
+            description: Desired read file format
+            example: BAM
+            required: false
+            schema:
+                $ref: '#/components/schemas/ReadsFormats'
+        variantsFormatParam:
+            in: query
+            name: format
+            description: Desired variant file format
+            example: VCF
+            required: false
+            schema:
+                type: string
+                enum: [VCF]
+                default: VCF
+        classParam:
+            in: query
+            name: class
+            description: Request different classes of data. By default, i.e., when class is not specified, the response will represent a complete read or variant data stream, encompassing SAM/CRAM/VCF headers, body data records, and EOF marker
+            example: header
+            required: false
+            schema:
+                type: string
+                enum: [header]
+        referenceNameParam:
+            in: query
+            name: referenceName
+            description: Reference sequence name
+            example: chr1
+            required: false
+            schema:
+                type: string
+        startParam:
+            in: query
+            name: start
+            description: The start position of the range on the reference, 0-based, inclusive
+            example: 12312
+            required: false
+            schema:
+                type: integer
+                format: int64
+                minimum: 0
+        endParam:
+            in: query
+            name: end
+            description: The end position of the range on the reference, 0-based, exclusive
+            example: 99999
+            required: false
+            schema:
+                type: integer
+                format: int64
+        readsFieldsParam:
+            in: query
+            name: fields
+            description: A comma-separated list of SAM fields to include. By default, i.e., when fields is not specified, all fields will be included
+            example: QNAME,RNAME
+            required: false
+            schema:
+                $ref: '#/components/schemas/ReadsFields'
+        variantsFieldsParam:
+            in: query
+            name: fields
+            description: Placeholder, currently does not do anything
+        readsTagsParam:
+            in: query
+            name: tags
+            description: A comma-separated list of tags to include. By default, i.e., when tags is not specified, all tags will be included
+            example: MD,NM
+            required: false
+            schema:
+                type: string
+        variantsTagsParam:
+            in: query
+            name: tags
+            description: Placeholder, currently does not do anything
+        readsNoTagsParam:
+            in: query
+            name: notags
+            description: A comma-separated list of tags to exclude. By default, i.e., when notags is not specified, no tags will be excluded
+            example: OQ
+            required: false
+            schema:
+                type: string
+        variantsNoTagsParam:
+            in: query
+            name: notags
+            description: Placeholder, currently does not do anything
+    requestBodies:
+        ReadsRequestBody:
+            description: Specify desired file format, fields, tags, and regions from an alignment file
+            required: false
+            content:
+                application/json:
+                    schema:
+                        $ref: '#/components/schemas/ReadsRequestBody'
+    responses:
+        400BadRequestError:
+            description: The request was not processed, as the request parameters did not adhere to the specification
+            content:
+                application/json:
+                    schema:
+                        $ref: '#/components/schemas/BadRequestError'
+        404NotFoundError:
+            description: The request was not processed, as the requested object was not found
+            content:
+                application/json:
+                    schema:
+                        $ref: '#/components/schemas/NotFoundError'
+        5xxServerError:
+            description: Unspecified server error encountered
+            content:
+                application/json:
+                    schema:
+                        $ref: '#/components/schemas/Error'


### PR DESCRIPTION
Added production config and docs to configure the server when running on AWS. An OpenAPI page provides documentation via ReDoc, and the production config is wired to serve data from tabula muris, 1000 genomes, genome in a bottle.